### PR TITLE
Cf data model

### DIFF
--- a/appi.adoc
+++ b/appi.adoc
@@ -19,7 +19,6 @@ CF conventions, and helps software developers to design CF-compliant
 data-processing applications and to build interfaces to other explicit
 data models.
 
-[introduction]
 == Introduction
 
 A data model is an abstract interpretation of the data, that

--- a/appi.adoc
+++ b/appi.adoc
@@ -88,7 +88,7 @@ and read data.
 [[img-netCDF, figure 1]]
 [.text-center]
 .Key components of the netCDF classic data model. Files consist of global attributes, dimensions and variables. Variables contain attributes and data, and attributes also contain data. Variables, attributes and dimensions all contain properties, such as a "name" which identifies them in the file. A data array has a data type for all of its elements (e.g. "double" for 64-bit floating point numbers).
-image::images/cfdm_netcdf_data_model.png[,50%]
+image::images/cfdm_netcdf_data_model.png[,50%,pdfwidth=50vw,align="center"]
 
 === Elements of CF-netCDF
 
@@ -150,7 +150,7 @@ CF-netCDF element
 [[img-cf-concepts, figure 2]]
 [.text-center]
 .The relationships between CF-netCDF elements and their corresponding netCDF variables, dimensions and attributes (defined in <<img-netCDF>> and identified here with the "NC" prefix). It is useful to define an abstract generic coordinate variable that can be used to refer to coordinates when the their type (coordinate, auxiliary or scalar coordinate variable) is not an issue. The CF convention details the mechanisms which are used in the netCDF file to express the relationships among the CF-netCDF elements, but these are not shown.
-image::images/cfdm_cf_concepts.png[,75%]
+image::images/cfdm_cf_concepts.png[,75%,pdfwidth=75vw,align="center"]
 
 
 == The CF data model
@@ -261,7 +261,7 @@ interpretation.
 [[img-field, figure 3]]
 [.text-center]
 .The constructs of the CF data model. The field construct corresponds to a CF-netCDF data variable (defined in <<img-cf-concepts>> and identified here with the "CN" prefix). Relationships between other constructs and CF-netCDF are given in <<img-dim-aux>> and <<img-coordinate-reference>>. The domain provides the linkage between the field construct and the constructs which describe measurement locations and cell properties. It is not a construct of the data model, but is an abstract concept that is useful for understanding it. Similarly, it is useful to define an abstract generic coordinate construct that can be used to refer to coordinates when the their type (dimension or auxiliary coordinate construct) is not an issue.
-image::images/cfdm_field.png[,50%]
+image::images/cfdm_field.png[,50%,pdfwidth=50vw,align="center"]
 
 === Domain axis construct and the data array
 
@@ -337,7 +337,7 @@ coordinate values. These axes are called "discrete" axes in CF-netCDF.
 [[img-dim-aux, figure 4]]
 [.text-center]
 .The relationship between domain axis, dimension coordinate and auxiliary coordinate constructs and CF-netCDF (defined in <<img-cf-concepts>> and identified here with the "CN" prefix). A dimension or auxiliary coordinate construct is defined by a CF-netCDF coordinate, scalar coordinate or auxiliary coordinate variable, and the associated CF-netCDF boundary variable if it exists. A generic coordinate construct spans one or more domain axis constructs, but the mapping of which ones is only held by the parent field construct.
-image::cfdm_coordinates.png[,75%]
+image::images/cfdm_coordinates.png[,75%,pdfwidth=50vw,align="center"]
 
 === Coordinate reference construct
 
@@ -424,7 +424,7 @@ if it is zero-dimensional, a scalar parameter.
 [[img-coordinate-reference, figure 5]]
 [.text-center]
 .The relationship between coordinate reference and domain ancillary constructs and CF-netCDF (defined in <<img-cf-concepts>> and identified here with the "CN" prefix). A coordinate reference construct is defined either by a grid mapping variable, or a **`formula_terms`** attribute of a CF-netCDF coordinate variable. The coordinate reference construct is composed of generic coordinate constructs, a datum, and a coordinate conversion formula. The coordinate conversion formula is usually defined by a named formula in the CF conventions. A domain ancillary construct term of a coordinate conversion formula is defined by a CF-netCDF data variable or a CF-netCDF generic coordinate variable.
-image::images/cfdm_coordinate_reference.png[,75%]
+image::images/cfdm_coordinate_reference.png[,75%,pdfwidth=75vw,align="center"]
 
 === Domain ancillary construct
 

--- a/cf-conventions.adoc
+++ b/cf-conventions.adoc
@@ -100,7 +100,7 @@ include::appg.adoc[]
 :numbered:
 include::apph.adoc[]
 
-:numbered:
+:numbered!:
 include::appi.adoc[]
 
 :numbered!:


### PR DESCRIPTION
- Removes the [introduction] tag which prompts an error from asciidoctor due to several (sub)sections in its range
- Fixes the `:numbered!:` attribute for Appendix I. Unfortunately the preceding Appendix H has the same error and this probably got copied over
- Improves the image handling by adding explicit alignment and scaling that works for pdf.